### PR TITLE
:sparkles: :arrow_up: Update eslint & plugins  + removal import/first

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,21 +19,21 @@
   "author": "Erwin Govaerts <erwin.govaerts@unbrace.be>",
   "license": "MIT",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.15.0",
-    "@typescript-eslint/parser": "^2.15.0",
+    "@typescript-eslint/eslint-plugin": "^4.1.1",
+    "@typescript-eslint/parser": "^4.1.1",
     "babel-eslint": "^10.0.3",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-flowtype": "^4.5.3",
-    "eslint-plugin-import": "2.19.1",
+    "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-lodash": "^6.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.17.0",
-    "eslint-plugin-react-hooks": "^1.7.0",
-    "typescript": "^3.7.4"
+    "eslint-plugin-react-hooks": "^4.1.2",
+    "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "eslint": "^6.8.0"
+    "eslint": "^7.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-unbrace",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Unbrace's shareable EsLint configuration",
   "main": "index.js",
   "repository": {

--- a/packages/core.json
+++ b/packages/core.json
@@ -103,12 +103,6 @@
         "json": "always"
       }
     ],
-    "import/first": [
-      2,
-      {
-        "absolute-first": true
-      }
-    ],
     "import/max-dependencies": [
       1,
       {


### PR DESCRIPTION
Removed import/first rule since it's already enforced by the import/order rule
Updated eslint + plugins to match BackOffice EsLint